### PR TITLE
Parsing I64 and U64 number properly

### DIFF
--- a/hjson/src/lib.rs
+++ b/hjson/src/lib.rs
@@ -46,7 +46,7 @@
 //!         println!("{}: {}", key, match *value {
 //!             Value::U64(v) => format!("{} (u64)", v),
 //!             Value::String(ref v) => format!("{} (string)", v),
-//!             _ => format!("other")
+//!             _ => unreachable!(),
 //!         });
 //!     }
 //!     // bar: baz (string)

--- a/hjson/src/value.rs
+++ b/hjson/src/value.rs
@@ -1410,3 +1410,36 @@ impl<T: ?Sized> ToJson for T
         to_value(&self)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Value;
+    use de::from_str;
+
+    #[test]
+    fn number_deserialize() {
+        let v: Value = from_str("{\"a\":1}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_u64().unwrap(), 1);
+
+        let v: Value = from_str("{\"a\":-1}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_i64().unwrap(), -1);
+
+        let v: Value = from_str("{\"a\":1.1}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_f64().unwrap(), 1.1);
+
+        let v: Value = from_str("{\"a\":-1.1}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_f64().unwrap(), -1.1);
+
+        let v: Value = from_str("{\"a\":1e6}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_f64().unwrap(), 1e6);
+
+        let v: Value = from_str("{\"a\":-1e6}").unwrap();
+        let vo = v.as_object().unwrap();
+        assert_eq!(vo["a"].as_f64().unwrap(), -1e6);
+    }
+}


### PR DESCRIPTION
This is a PR for #8 .

- Removed unused macro `try_or_invalid`.
- Parse number into `i64` or `u64` if possible.