### PR TITLE
Make extern crate linked_hash_map conditional

### DIFF
--- a/hjson/src/lib.rs
+++ b/hjson/src/lib.rs
@@ -59,8 +59,9 @@
 
 #[macro_use] extern crate lazy_static;
 
-extern crate core;
+#[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
+extern crate core;
 extern crate num_traits;
 extern crate regex;
 extern crate serde;


### PR DESCRIPTION
The dependency on linked_hash_map is optional, but there was an `extern crate linked_hash_map` that was not under a conditional flag and this gives compiler errors, when "preserve_order" is not set since the dependency is missing.

This adds the conditional avoiding trying to import the crate when "preserve_order" is not set.