### PR TITLE
don't crash when deserializing out of bound integers

### DIFF
--- a/hjson/src/de.rs
+++ b/hjson/src/de.rs
@@ -852,3 +852,21 @@ pub fn from_str<T>(s: &str) -> Result<T>
 {
     from_slice(s.as_bytes())
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use Value;
+
+    #[test]
+    fn out_of_bound_negative_numbers_dont_cause_crashes() {
+        let value = "[-9223372036854775809]".to_string();
+        let _ = from_str::<Value>(&value);
+    }
+
+    #[test]
+    fn out_of_bound_positive_numbers_dont_cause_crashes() {
+        let value = "[18446744073709551616]".to_string();
+        let _ = from_str::<Value>(&value);
+    }
+}

--- a/hjson/src/error.rs
+++ b/hjson/src/error.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::io;
 use std::result;
 use std::string::FromUtf8Error;
+use std::num::ParseIntError;
 
 use serde::de;
 use serde::ser;
@@ -133,6 +134,9 @@ pub enum Error {
 
     /// Some UTF8 error occurred while serializing or deserializing a value.
     FromUtf8(FromUtf8Error),
+
+    /// Some error occurred while deserializing a number.
+    ParseIntError(ParseIntError),
 }
 
 impl error::Error for Error {
@@ -141,6 +145,7 @@ impl error::Error for Error {
             Error::Syntax(..) => "syntax error",
             Error::Io(ref error) => error::Error::description(error),
             Error::FromUtf8(ref error) => error.description(),
+            Error::ParseIntError(ref error) => error.description(),
         }
     }
 
@@ -148,6 +153,7 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref error) => Some(error),
             Error::FromUtf8(ref error) => Some(error),
+            Error::ParseIntError(ref error) => Some(error),
             _ => None,
         }
     }
@@ -162,6 +168,7 @@ impl fmt::Display for Error {
             }
             Error::Io(ref error) => fmt::Display::fmt(error, fmt),
             Error::FromUtf8(ref error) => fmt::Display::fmt(error, fmt),
+            Error::ParseIntError(ref error) => fmt::Display::fmt(error, fmt),
         }
     }
 }
@@ -206,6 +213,12 @@ impl From<de::value::Error> for Error {
                 Error::Syntax(ErrorCode::MissingField(field), 0, 0)
             }
         }
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(error: ParseIntError) -> Error {
+        Error::ParseIntError(error)
     }
 }
 

--- a/hjson/src/util.rs
+++ b/hjson/src/util.rs
@@ -203,9 +203,9 @@ impl<Iter: Iterator<Item=u8>> ParseNumber<Iter> {
                             Ok(Number::F64(res.parse::<f64>().unwrap()))
                         } else {
                             if res.starts_with("-") {
-                                Ok(Number::I64(res.parse::<i64>().unwrap()))
+                                Ok(Number::I64(try!(res.parse::<i64>())))
                             } else {
-                                Ok(Number::U64(res.parse::<u64>().unwrap()))
+                                Ok(Number::U64(try!(res.parse::<u64>())))
                             }
                         }
                     },


### PR DESCRIPTION
Before this PR `de::from_str` would panic when trying to parse out of bound integers. Now it returns an error. (It would be nicer if it would parse the numbers successfully, e.g. as floats or big integers. But returning an error is definitely better than panicking.)

Please let me know if I broke any coding conventions.