### PR TITLE
Removed skeptic

### DIFF
--- a/hjson_tests/Cargo.toml
+++ b/hjson_tests/Cargo.toml
@@ -2,18 +2,13 @@
 name = "serde-hjson-tests"
 version = "0.8.2"
 authors = ["Christian Zangl <laktak@cdak.net>"]
-build = "build.rs"
 edition = "2018"
-
-[build-dependencies]
-skeptic = "0.13"
 
 [dependencies]
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde-hjson = { version = "*", path = "../hjson" }
-skeptic = "0.13"
 
 [[test]]
 name = "test"

--- a/hjson_tests/build.rs
+++ b/hjson_tests/build.rs
@@ -1,3 +1,0 @@
-pub fn main() {
-    skeptic::generate_doc_tests(&["../README.md"]);
-}

--- a/hjson_tests/tests/test.rs
+++ b/hjson_tests/tests/test.rs
@@ -1,6 +1,1 @@
 mod test_hjson;
-
-mod skeptic_tests {
-
-include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));
-}


### PR DESCRIPTION
It seems like cargo test doc does the exact thing. Dropping that dependency should cause no pain 