### PR TITLE
Set MSRV to 1.65.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: cd hjson && cargo build --release
-      - run: cd hjson_cli && cargo build --release
-      - run: cargo test -- --nocapture
+      - if: matrix.rust != '1.65.0'
+        run: cd hjson_cli && cargo build --release
+      - run: |
+          if [ '${{ matrix.rust }}' == '1.65.0' ]; then
+            # because of 'clap_derive' it needs Rust 1.74+
+            cargo test --workspace --exclude hjson -- --nocapture
+          else
+            cargo test --workspace -- --nocapture
+          fi
       - run: cd hjson && cargo doc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,33 @@
 name: test
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   test:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} / Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         rust: [stable]
+        include:
+          - os: ubuntu-latest
+            rust: 1.65.0 # MSRV
+          - os: ubuntu-latest
+            rust: beta
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
       - run: cd hjson && cargo build --release
       - run: cd hjson_cli && cargo build --release
       - run: cargo test -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["hjson", "hjson_cli", "hjson_tests"]
+resolver = "2"

--- a/hjson/Cargo.toml
+++ b/hjson/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/hjson/hjson-rust"
 #documentation = "https://hjson.github.io/hjson-rust/"
 readme = "../README.md"
 keywords = ["hjson", "json", "serde", "serialization"]
+edition = "2021"
+rust-version = "1.65" # MSRV
 
 [features]
 preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]

--- a/hjson/src/builder.rs
+++ b/hjson/src/builder.rs
@@ -35,7 +35,7 @@
 
 use serde::ser;
 
-use value::{self, Map, Value};
+use super::value::{self, Map, Value};
 
 /// This structure provides a simple interface for constructing a JSON array.
 pub struct ArrayBuilder {

--- a/hjson/src/de.rs
+++ b/hjson/src/de.rs
@@ -827,7 +827,7 @@ pub fn from_str<T>(s: &str) -> Result<T>
 where
     T: de::DeserializeOwned,
 {
-    if s.chars().last().is_some_and(|x| x.is_whitespace()) {
+    if s.chars().last().map_or(false, |x| x.is_whitespace()) {
         from_slice(s.as_bytes())
     } else {
         let s = format!("{s}\n");

--- a/hjson/src/value.rs
+++ b/hjson/src/value.rs
@@ -47,7 +47,7 @@ use num_traits::NumCast;
 
 use serde::{de, ser};
 
-use error::{Error, ErrorCode};
+use super::error::{Error, ErrorCode};
 
 type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -1188,7 +1188,7 @@ where
 #[cfg(test)]
 mod test {
     use super::Value;
-    use de::from_str;
+    use super::super::de::from_str;
 
     #[test]
     fn number_deserialize() {

--- a/hjson_cli/Cargo.toml
+++ b/hjson_cli/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Hjson serialization file format"
 repository = "https://github.com/hjson/hjson-rust"
 keywords = ["hjson", "json", "serde", "serialization"]
+edition = "2021"
 
 [dependencies]
 serde = "1.0"

--- a/hjson_tests/Cargo.toml
+++ b/hjson_tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "serde-hjson-tests"
 version = "1.0.0"
 authors = ["Christian Zangl <laktak@cdak.net>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 regex = "1.10"


### PR DESCRIPTION
- this is the same minimal version as the used `regex` crate
- also added CI variants for Rust version `1.65.0` and `beta`. I had to exclude package `hjson`, which is the CLI package, because `clap` needs Rust version 1.74+
- to comply with version `1.65.0` I had to slightly rewrite the `is_some_and()` condition, which I hope is ok
- updated to Rust edition `2021`, which only resulted in a few import fixes
- slightly improved CI in general by limiting permissions to only reading the actual content of the repo and only build on push events, when it is the `main` branch, otherwise CI actually runs twice during a PR 😅 I will probably create a follow-up PR to further improve CI, didn't want to make to much changes in that area.