### PR TITLE
add fmt and clippy check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,18 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: format check
+        run: cargo fmt --check --all
+      - name: clippy check
+        run: cargo clippy --workspace
+
   test:
     name: ${{ matrix.os }} / Rust ${{ matrix.rust }}
     runs-on: ${{ matrix.os }}

--- a/hjson/src/builder.rs
+++ b/hjson/src/builder.rs
@@ -38,14 +38,15 @@ use serde::ser;
 use super::value::{self, Map, Value};
 
 /// This structure provides a simple interface for constructing a JSON array.
+#[derive(Default)]
 pub struct ArrayBuilder {
     array: Vec<Value>,
 }
 
 impl ArrayBuilder {
     /// Construct an `ObjectBuilder`.
-    pub fn new() -> ArrayBuilder {
-        ArrayBuilder { array: Vec::new() }
+    pub fn new() -> Self {
+        Self { array: Vec::new() }
     }
 
     /// Return the constructed `Value`.
@@ -84,14 +85,15 @@ impl ArrayBuilder {
 }
 
 /// This structure provides a simple interface for constructing a JSON object.
+#[derive(Default)]
 pub struct ObjectBuilder {
     object: Map<String, Value>,
 }
 
 impl ObjectBuilder {
     /// Construct an `ObjectBuilder`.
-    pub fn new() -> ObjectBuilder {
-        ObjectBuilder { object: Map::new() }
+    pub fn new() -> Self {
+        Self { object: Map::new() }
     }
 
     /// Return the constructed `Value`.

--- a/hjson/src/error.rs
+++ b/hjson/src/error.rs
@@ -129,7 +129,7 @@ impl error::Error for Error {
         match *self {
             Error::Io(ref error) => Some(error),
             Error::FromUtf8(ref error) => Some(error),
-            _ => None,
+            Error::Syntax(..) => None,
         }
     }
 }

--- a/hjson/src/lib.rs
+++ b/hjson/src/lib.rs
@@ -50,6 +50,8 @@
 //! ```
 
 #![deny(missing_docs)]
+#![allow(clippy::match_like_matches_macro)]
+#![allow(clippy::needless_doctest_main)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/hjson_cli/src/main.rs
+++ b/hjson_cli/src/main.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(clap::Parser, Clone, Debug)]
 #[group(id = "formatting", required = false, multiple = false)]


### PR DESCRIPTION
- I disabled 2 of the default clippy lints `match_like_matches_macro` and `needless_doctest_main`. I was not sure, if you like the `matches!(...)` macro style or not and the second relates to the main example,  so kept it as is.
- if you don't like specific changes, then let me know and I can revert them and either disable the lint or exclude it specifically there 